### PR TITLE
Optimized __deserialize_datatime by attempting strptime

### DIFF
--- a/aylien_news_api/api_client.py
+++ b/aylien_news_api/api_client.py
@@ -567,7 +567,9 @@ class ApiClient(object):
         """
         try:
             try:
-                return datetime.strptime(string, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=pytz.UTC)
+                values = [string[:4], ] + [string[i:i+2] for i in range(5, 18, 3)]
+                values = map(int, values)
+                return datetime(*values).replace(tzinfo=pytz.UTC)
             except ValueError:
                 from dateutil.parser import parse
                 return parse(string)

--- a/aylien_news_api/api_client.py
+++ b/aylien_news_api/api_client.py
@@ -31,6 +31,8 @@ import threading
 from datetime import datetime
 from datetime import date
 
+import pytz
+
 # python 2 and python 3 compatibility library
 from six import PY3, integer_types, iteritems, text_type
 from six.moves.urllib.parse import quote
@@ -564,8 +566,11 @@ class ApiClient(object):
         :return: datetime.
         """
         try:
-            from dateutil.parser import parse
-            return parse(string)
+            try:
+                return datetime.strptime(string, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=pytz.UTC)
+            except ValueError:
+                from dateutil.parser import parse
+                return parse(string)
         except ImportError:
             return string
         except ValueError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ six == 1.8.0
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.15.1
+pytz >= 2016.6.1


### PR DESCRIPTION
The deserialization is a little slow.
Using the `datetime.strptime` instead of `parser.parse` is much faster.